### PR TITLE
Cluster endpoint

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -101,17 +101,3 @@ EOF
     content      = "${module.puppet_userdata.user_datas[count.index]}"
   }
 }
-
-data "aws_route53_zone" "domain" {
-  count = "${var.r53_domain == "" ? 0 : 1}"
-  name  = "${var.environment}.${var.r53_domain}"
-}
-
-resource "aws_route53_record" "core_record" {
-  count   = "${var.r53_domain == "" ? 0 : var.core_count}"
-  zone_id = "${data.aws_route53_zone.domain.zone_id}"
-  name    = "${var.project}-${var.name}-core${format("%02d", count.index + 1)}.${data.aws_route53_zone.domain.name}"
-  type    = "A"
-  ttl     = "60"
-  records = ["${module.core.instance_private_ip[count.index]}"]
-}

--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ resource "aws_volume_attachment" "core_attach" {
 }
 
 module "puppet_userdata" {
-  source              = "github.com/skyscrapers/terraform-skyscrapers//puppet-userdata?ref=1.0.2"
+  source              = "github.com/skyscrapers/terraform-instances//puppet-userdata?ref=2.1.0"
   amount_of_instances = "${var.core_count}"
   customer            = "${var.customer == "" ? var.project : format("%s-%s", var.customer, var.project)}"
   environment         = "${var.environment}"

--- a/r53.tf
+++ b/r53.tf
@@ -13,9 +13,10 @@ resource "aws_route53_record" "core_record" {
 }
 
 resource "aws_route53_record" "cluster_record" {
-  zone_id                          = "${data.aws_route53_zone.domain.zone_id}"
-  name                             = "${var.project}-${var.name}.${data.aws_route53_zone.domain.name}"
-  type                             = "A"
-  ttl                              = "60"
-  records                          = ["${module.core.instance_private_ip}"]
+  count   = "${var.r53_domain == "" ? 0 : 1}"
+  zone_id = "${data.aws_route53_zone.domain.zone_id}"
+  name    = "${var.project}-${var.name}.${data.aws_route53_zone.domain.name}"
+  type    = "A"
+  ttl     = "60"
+  records = ["${module.core.instance_private_ip}"]
 }

--- a/r53.tf
+++ b/r53.tf
@@ -13,12 +13,9 @@ resource "aws_route53_record" "core_record" {
 }
 
 resource "aws_route53_record" "cluster_record" {
-  count                            = "${var.r53_domain == "" ? 0 : var.core_count}"
   zone_id                          = "${data.aws_route53_zone.domain.zone_id}"
   name                             = "${var.project}-${var.name}.${data.aws_route53_zone.domain.name}"
   type                             = "A"
   ttl                              = "60"
-  records                          = ["${module.core.instance_private_ip[count.index]}"]
-  multivalue_answer_routing_policy = true
-  set_identifier                   = "${var.project}-${var.name}-core${format("%02d", count.index + 1)}"
+  records                          = ["${module.core.instance_private_ip}"]
 }

--- a/r53.tf
+++ b/r53.tf
@@ -1,0 +1,24 @@
+data "aws_route53_zone" "domain" {
+  count = "${var.r53_domain == "" ? 0 : 1}"
+  name  = "${var.environment}.${var.r53_domain}"
+}
+
+resource "aws_route53_record" "core_record" {
+  count   = "${var.r53_domain == "" ? 0 : var.core_count}"
+  zone_id = "${data.aws_route53_zone.domain.zone_id}"
+  name    = "${var.project}-${var.name}-core${format("%02d", count.index + 1)}.${data.aws_route53_zone.domain.name}"
+  type    = "A"
+  ttl     = "60"
+  records = ["${module.core.instance_private_ip[count.index]}"]
+}
+
+resource "aws_route53_record" "cluster_record" {
+  count                            = "${var.r53_domain == "" ? 0 : var.core_count}"
+  zone_id                          = "${data.aws_route53_zone.domain.zone_id}"
+  name                             = "${var.project}-${var.name}.${data.aws_route53_zone.domain.name}"
+  type                             = "A"
+  ttl                              = "60"
+  records                          = ["${module.core.instance_private_ip[count.index]}"]
+  multivalue_answer_routing_policy = true
+  set_identifier                   = "${var.project}-${var.name}-core${format("%02d", count.index + 1)}"
+}

--- a/r53.tf
+++ b/r53.tf
@@ -1,6 +1,6 @@
 data "aws_route53_zone" "domain" {
   count = "${var.r53_domain == "" ? 0 : 1}"
-  name  = "${var.environment}.${var.r53_domain}"
+  name  = "${var.r53_domain}"
 }
 
 resource "aws_route53_record" "core_record" {


### PR DESCRIPTION
Add a multi-value R53 record pointing to all neo4j nodes in the cluster. Health checking is not included since you need public endpoints for that.

Also updating the r53 domain lookup to exclude the environment variable, so you have full control over the domain.